### PR TITLE
[magik-treesit] Remove unknown operator `_xorif`

### DIFF
--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -80,7 +80,7 @@
    `([(false) (true) (maybe)] @magik-boolean-face
      [(unset) "_constant"] @magik-constant-face
 
-     ["_and" "_andif" "_div" "_is" "_isnt" "_cf" "_mod" "_not" "_or" "_orif" "_xor" "_xorif"] @magik-keyword-operators-face
+     ["_and" "_andif" "_div" "_is" "_isnt" "_cf" "_mod" "_not" "_or" "_orif" "_xor"] @magik-keyword-operators-face
 
      [(self) (super) (clone)] @magik-class-face
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined the set of recognized keyword operations by removing an extraneous operator. This update streamlines internal processing and promotes consistent behavior. While the underlying configuration was optimized, users will experience enhanced reliability in operations without any noticeable changes to the visual interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->