### PR TITLE
Use `derived-mode-p` instead of `eq major-mode`

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -158,10 +158,9 @@ You can customise `magik-aliases-mode' with the `magik-aliases-mode-hook'.
 
 (defun magik-aliases-kill-buffer ()
   "Function to run when an Aliases mode buffer is run."
-  (if (eq major-mode 'magik-aliases-mode)
-      (progn
-        (setq major-mode 'fundamental-mode) ; prevent current buffer being listed.
-        (magik-aliases-update-sw-menu))))
+  (when (derived-mode-p 'magik-aliases-mode)
+    (setq major-mode 'fundamental-mode) ;; prevent current buffer being listed.
+    (magik-aliases-update-sw-menu)))
 
 (defun magik-aliases-n ()
   "If buffer is read-only goto next alias, else insert SPC."
@@ -307,9 +306,9 @@ With a prefix arg, ask user for current directory to use."
       (setq default-directory dir
             args (append (list program) args))
       (compat-call setq-local
-            magik-session-exec-path (cl-copy-list (or exec-path-aliases exec-path))
-            magik-session-process-environment (cl-copy-list (or process-environment-aliases process-environment))
-            magik-session-current-command (mapconcat 'identity args " "))
+                   magik-session-exec-path (cl-copy-list (or exec-path-aliases exec-path))
+                   magik-session-process-environment (cl-copy-list (or process-environment-aliases process-environment))
+                   magik-session-current-command (mapconcat 'identity args " "))
       (if (stringp version)
           (set 'magik-version-current version))
 
@@ -414,16 +413,16 @@ Returns nil if FILE can't be expanded."
 (defun magik-aliases-update-menu ()
   "Update the dynamic Aliases submenu."
   (interactive)
-  (if (eq major-mode 'magik-aliases-mode)
-      (let ((aliases (magik-aliases-list))
-            entries def)
-        (while aliases
-          (setq def (car aliases)
-                aliases (cdr aliases)
-                entries (nconc entries (list (vector def (list 'magik-aliases-run-program def) t)))))
-        (easy-menu-change (list "Aliases")
-                          "Definitions"
-                          (or entries (list "No Aliases found"))))))
+  (when (derived-mode-p 'magik-aliases-mode)
+    (let ((aliases (magik-aliases-list))
+          entries def)
+      (while aliases
+        (setq def (car aliases)
+              aliases (cdr aliases)
+              entries (nconc entries (list (vector def (list 'magik-aliases-run-program def) t)))))
+      (easy-menu-change (list "Aliases")
+                        "Definitions"
+                        (or entries (list "No Aliases found"))))))
 
 (defun magik-aliases-update-sw-menu ()
   "Update `Alias Files' submenu in SW menu bar."
@@ -488,7 +487,7 @@ Returns nil if FILE can't be expanded."
          (handle (1- (nth 1 last))))
     (setcdr precdr (list
                     (list
-                     '(eq major-mode 'magik-aliases-mode)
+                     '(derived-mode-p 'magik-aliases-mode)
                      handle
                      "Aliases Files (%d)")
                     last))))

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -417,8 +417,8 @@ Set METHOD and CLASS if given."
            (setq gis (magik-utils-get-buffer-mode gis
                                                   'magik-session-mode
                                                   "Enter Magik Session buffer:"
-                                                  (cond ((eq major-mode 'magik-cb-mode) (magik-cb-gis-buffer))
-                                                        ((eq major-mode 'magik-session-mode) (buffer-name))
+                                                  (cond ((derived-mode-p 'magik-cb-mode) (magik-cb-gis-buffer))
+                                                        ((derived-mode-p 'magik-session-mode) (buffer-name))
                                                         (t magik-session-buffer))
                                                   'magik-session-buffer-alist-prefix-function))
            (unless (get-buffer-process gis)
@@ -444,9 +444,9 @@ Set METHOD and CLASS if given."
                  buffer (generate-new-buffer-name
                          (concat "*cb*" "*" (or buffer (file-name-nondirectory magik-cb-file)) "*"))
                  gis    (magik-cb-gis-buffer buffer)))
-          ((eq major-mode 'magik-cb-mode)
+          ((derived-mode-p 'magik-cb-mode)
            (setq gis (magik-cb-gis-buffer)))
-          ((eq major-mode 'magik-session-mode)
+          ((derived-mode-p 'magik-session-mode)
            (setq gis (buffer-name)))
           ((and ;List of *visible* cb-mode *and* magik-session-mode buffers.
             (setq bufs
@@ -819,7 +819,7 @@ If FILTER is given then it is set on the process."
             (save-excursion
               (let ((version (magik-cb-method-finder-version)))
                 (set-buffer (get-buffer-create buffer))
-                (unless (eq major-mode 'magik-cb-mode)
+                (unless (derived-mode-p 'magik-cb-mode)
                   (magik-cb-mode))
                 (compat-call setq-local
                              magik-cb-quote-file-name   (version< "5.2.0" version)
@@ -932,8 +932,8 @@ If FILTER is given then it is set on the process."
                                                         (substring magik-cb-filter-str (match-beginning 0))
                                                       ""))
 
-        (if jump-str
-            (magik-cb-goto-method jump-str (eq major-mode 'magik-cb-mode)))))))
+        (when jump-str
+          (magik-cb-goto-method jump-str (derived-mode-p 'magik-cb-mode)))))))
 
 (defun magik-cb-read-methods (p)
   "Deal with control characters coming back from buffer P.
@@ -1856,7 +1856,7 @@ Copied to \"*cb*\" and \"*cb2*\" modelines and put in a (') character."
   "Either toggle a class browser flag or show a class hierarchy using CLICK."
   (interactive "e")
   (mouse-set-point click)
-  (cond ((eq major-mode 'magik-cb-mode)
+  (cond ((derived-mode-p 'magik-cb-mode)
          (if (save-excursion (search-backward " " (line-beginning-position) t))
              (magik-cb-family (magik-utils-find-tag-default))
            (magik-cb-jump-to-source)))
@@ -2173,7 +2173,7 @@ Defined in `magik-cb-current-jump'."
 (defun magik-cb-jump-to-source ()
   "Jump to the source for the method under the cursor."
   (interactive)
-  (if (eq major-mode 'magik-cb-mode)
+  (if (derived-mode-p 'magik-cb-mode)
       (magik-cb-jump-to-source-from-cb)
     (setq magik-cb-temp-method-name (magik-cb-curr-method-name))
     (magik-cb nil magik-cb-temp-method-name "")))
@@ -2398,7 +2398,7 @@ See the variable `magik-cb-generalise-file-name-alist' for more customisation."
          (handle (1- (nth 1 last))))
     (setcdr precdr (list
                     (list
-                     '(eq major-mode 'magik-cb-mode)
+                     '(derived-mode-p 'magik-cb-mode)
                      handle
                      "CB (%d)")
                     last))))

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -883,8 +883,8 @@ Optional argument ARG .."
 (defun magik-newline ()
   "Insert a newline and indent.  (To insert a newline and not indent, use \\[electric-newline-and-maybe-indent])."
   (interactive "*")
-  (if (eq major-mode 'magik-session-mode)
-      (error "Your Magik shell buffer has got into magik-mode! To recover, type `M-x magik-session-mode'.  Please report this bug"))
+  (when (derived-mode-p 'magik-session-mode)
+    (error "Your Magik shell buffer has got into magik-mode! To recover, type `M-x magik-session-mode'.  Please report this bug"))
   (if abbrev-mode (save-excursion (expand-abbrev)))
   (if (save-excursion
         (back-to-indentation)
@@ -2167,7 +2167,7 @@ Prevents expansion inside strings and comments."
 (defun magik--snippets-initialize ()
   "Initialize the Magik snippets."
   (let ((snip-dir (expand-file-name "snippets" (file-name-directory (or load-file-name (buffer-file-name))))))
-   (when (boundp 'yas-snippet-dirs)
+    (when (boundp 'yas-snippet-dirs)
       (add-to-list 'yas-snippet-dirs snip-dir t))
     (yas-load-directory snip-dir)))
 

--- a/magik-msg.el
+++ b/magik-msg.el
@@ -226,7 +226,7 @@ Called by `magik-session-drag-n-drop-load' when a Msg FILENAME is dropped."
          (handle (1- (nth 1 last))))
     (setcdr precdr (list
                     (list
-                     '(eq major-mode 'magik-msg-mode)
+                     '(derived-mode-p 'magik-msg-mode)
                      handle
                      "Msg Files (%d)")
                     last))))

--- a/magik-session.el
+++ b/magik-session.el
@@ -446,41 +446,41 @@ Return a list of all the components of the COMMAND."
 
 (defun magik-session-update-magik-session-menu ()
   "Update the Magik Session Command history in the Magik Session pulldown menu."
-  (if (eq major-mode 'magik-session-mode)
-      (let (command-list)
-        (save-match-data
-          ;;Delete duplicates from magik-session-command-history local and global values
-          ;;Note: delete-duplicates does not appear to work on localised variables.
-          (compat-call setq-local magik-session-command-history (cl-remove-duplicates magik-session-command-history :test 'equal))
-          (setq-default magik-session-command-history
-                        (cl-remove-duplicates (default-value 'magik-session-command-history)
-                                              :test 'equal))
+  (when (derived-mode-p 'magik-session-mode)
+    (let (command-list)
+      (save-match-data
+        ;;Delete duplicates from magik-session-command-history local and global values
+        ;;Note: delete-duplicates does not appear to work on localised variables.
+        (compat-call setq-local magik-session-command-history (cl-remove-duplicates magik-session-command-history :test 'equal))
+        (setq-default magik-session-command-history
+                      (cl-remove-duplicates (default-value 'magik-session-command-history)
+                                            :test 'equal))
 
-          (dolist (command magik-session-command-history)
-            (push (apply
-                   'vector
-                   (magik-session-command-display command)
-                   (list 'gis (buffer-name) (purecopy command))
-                   ':active
-                   '(not (get-buffer-process (buffer-name)))
-                   ;; ':key-sequence nil
-                   (list ':help (purecopy command)))
-                  command-list)))
+        (dolist (command magik-session-command-history)
+          (push (apply
+                 'vector
+                 (magik-session-command-display command)
+                 (list 'gis (buffer-name) (purecopy command))
+                 ':active
+                 '(not (get-buffer-process (buffer-name)))
+                 ;; ':key-sequence nil
+                 (list ':help (purecopy command)))
+                command-list)))
 
-        (if (get-buffer-process (buffer-name))
-            (setq command-list
-                  (append command-list
-                          (list "---"
-                                (apply 'vector (magik-session-command-display magik-session-current-command)
-                                       'ignore ':active nil (list ':key-sequence nil
-                                                                  ':help (purecopy magik-session-current-command)))
-                                (apply 'vector "Start New Magik Session" 'magik-session-new-buffer
-                                       ':active t
-                                       ':keys '("C-u f2 z"))))))
+      (if (get-buffer-process (buffer-name))
+          (setq command-list
+                (append command-list
+                        (list "---"
+                              (apply 'vector (magik-session-command-display magik-session-current-command)
+                                     'ignore ':active nil (list ':key-sequence nil
+                                                                ':help (purecopy magik-session-current-command)))
+                              (apply 'vector "Start New Magik Session" 'magik-session-new-buffer
+                                     ':active t
+                                     ':keys '("C-u f2 z"))))))
 
-        (easy-menu-change (list "Magik Session")
-                          "Magik Session Command History"
-                          (or command-list (list "No History"))))))
+      (easy-menu-change (list "Magik Session")
+                        "Magik Session Command History"
+                        (or command-list (list "No History"))))))
 
 (defun magik-session-update-tools-magik-shell-menu ()
   "Update External Shell Processes submenu in Tools -> Magik pulldown menu."
@@ -701,7 +701,7 @@ there is not, prompt for a command to run, and then run it."
         (keepgoing t)
         (magik-session-start-process-pre-hook magik-session-start-process-pre-hook)
         (buffer (magik-utils-get-buffer-mode (cond (buffer buffer)
-                                                   ((eq major-mode 'magik-session-mode) (buffer-name))
+                                                   ((derived-mode-p 'magik-session-mode) (buffer-name))
                                                    (t nil))
                                              'magik-session-mode
                                              "Enter Magik Session buffer:"
@@ -770,7 +770,7 @@ there is not, prompt for a command to run, and then run it."
         (kill-buffer alias-buffer))
 
       (pop-to-buffer (get-buffer-create buffer))
-      (unless (eq major-mode 'magik-session-mode)
+      (unless (derived-mode-p 'magik-session-mode)
         (magik-session-mode))
       (goto-char (point-max))
       (insert "\n" (current-time-string) "\n")
@@ -1243,7 +1243,7 @@ If ARG is null, use a default of `magik-session-history-length'."
   (setq arg (if (null arg) magik-session-history-length (prefix-numeric-value arg)))
   (let
       ((b (current-buffer)))
-    (or (eq major-mode 'magik-session-mode)
+    (or (derived-mode-p 'magik-session-mode)
         (set-buffer magik-session-buffer))
     (compat-call setq-local selective-display t)
     (let
@@ -1288,7 +1288,7 @@ If ARG is null, use a default of `magik-session-history-length'."
   (setq arg (if (null arg) magik-session-history-length (prefix-numeric-value arg)))
   (let
       ((b (current-buffer)))
-    (or (eq major-mode 'magik-session-mode)
+    (or (derived-mode-p 'magik-session-mode)
         (set-buffer magik-session-buffer))
     (compat-call setq-local selective-display t)
     (let
@@ -1496,7 +1496,7 @@ where MODE is the name of the major mode with the '-mode' postfix."
              (with-current-buffer gis
 
                (and magik-session-drag-n-drop-mode
-                    (eq major-mode 'magik-session-mode))))
+                    (derived-mode-p 'magik-session-mode))))
         (funcall fn gis (buffer-file-name)))))
 
 (defun magik-session-disable-save ()
@@ -1531,7 +1531,7 @@ where MODE is the name of the major mode with the '-mode' postfix."
          (handle (1- (nth 1 last))))
     (setcdr precdr (list
                     (list
-                     '(eq major-mode 'magik-session-mode)
+                     '(derived-mode-p 'magik-session-mode)
                      handle
                      "Magik (%d)")
                     last))))

--- a/magik-version.el
+++ b/magik-version.el
@@ -276,8 +276,8 @@ installation directory suitable for selection."
     (let ((inhibit-read-only t))
       (insert (format magik-version-file-format name version root))
       (save-buffer)))
-  (if (eq major-mode 'magik-version-mode)
-      (magik-version-selection)))
+  (when (derived-mode-p 'magik-version-mode)
+    (magik-version-selection)))
 
 (defun magik-version-file-open ()
   "Open the magik-version-file to edit."
@@ -497,16 +497,16 @@ Used before running a GIS process."
 (defun magik-versions-update-menu ()
   "Update the dynamic Versions submenu."
   (interactive)
-  (if (eq major-mode 'magik-version-mode)
-      (let ((versions (magik-versions-list))
-            entries def)
-        (while versions
-          (setq def (car versions)
-                versions (cdr versions)
-                entries (nconc entries (list (vector def (list 'magik-version-select def) t)))))
-        (easy-menu-change (list "Environment")
-                          "Definitions"
-                          (or entries (list "No Versions found"))))))
+  (when (derived-mode-p 'magik-version-mode)
+    (let ((versions (magik-versions-list))
+          entries def)
+      (while versions
+        (setq def (car versions)
+              versions (cdr versions)
+              entries (nconc entries (list (vector def (list 'magik-version-select def) t)))))
+      (easy-menu-change (list "Environment")
+                        "Definitions"
+                        (or entries (list "No Versions found"))))))
 
 ;;; Package initialisation
 (modify-syntax-entry ?_  "w"  magik-version-mode-syntax-table)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated mode-checking logic to use derived-mode evaluations, ensuring correct recognition of derived modes across functionalities.
- **Style**
  - Improved formatting and indentation for better overall code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->