### PR TITLE
[magik-yasnippet] Toggle between different documentation styles

### DIFF
--- a/snippets/magik-mode/.yas-setup.el
+++ b/snippets/magik-mode/.yas-setup.el
@@ -6,6 +6,9 @@
 
 (require 'yasnippet)
 
+;; Suppress the warnings about modifying the buffer via a snippet
+(add-to-list 'warning-suppress-types '(yasnippet backquote-change))
+
 (defgroup magik-yasnippet nil
   "Customise Magik YASnippet group."
   :tag   "Magik YASnippet"
@@ -16,7 +19,45 @@
   :group 'magik-yasnippet
   :type  'string)
 
-(defconst magik-yasnippet--class-name-regexp "\\(\\(\\sw\\|_\\)+\\)" "The regexp to use for the Magik class name.")
+(defcustom magik-yasnippet-documentation-style 'sw-method-docs
+  "Choose between \\'sw-method-docs\\', \\'type-docs\\', or nil.
+\\'sw-method-docs\\' for Smallworld method documentation style.
+\\'type-docs\\' for type-based documentation.
+nil to disable documentation."
+  :group 'magik-yasnippet
+  :type  '(choice (const :tag "Smallworld Method Docs" sw-method-docs)
+                  (const :tag "Type Docs" type-docs)
+                  (const :tag "No Documentation" nil)))
+
+(defcustom magik-yasnippet-default-documentation "\t## \n\t## \n\t## "
+  "Default documentation string to insert."
+  :group 'magik-yasnippet
+  :type  'string)
+
+(defcustom magik-yasnippet-sw-method-docs-documentation magik-yasnippet-default-documentation
+  "Default sw-method-docs documentation string to insert."
+  :group 'magik-yasnippet
+  :type  'string)
+
+(defcustom magik-yasnippet-type-docs-documentation magik-yasnippet-default-documentation
+  "Default type-docs documentation string to insert."
+  :group 'magik-yasnippet
+  :type  'string)
+
+(defconst magik-yasnippet--class-name-regexp "\\(\\(\\sw\\|_\\)+\\)"
+  "The regexp to use for the Magik class name.")
+
+(defun magik-yasnippet-documentation (&optional untabbed)
+  "Insert the documentation string based on `magik-yasnippet-documentation-style'.
+If UNTABBED is non-nil remove the tabs from the documentation string."
+  (if magik-yasnippet-documentation-style
+      (let ((documentation-string (pcase magik-yasnippet-documentation-style
+                                    ('sw-method-docs magik-yasnippet-sw-method-docs-documentation)
+                                    ('type-docs magik-yasnippet-type-docs-documentation))))
+        (if untabbed
+            (replace-regexp-in-string "\t" "" documentation-string)
+          documentation-string))
+    (kill-line)))
 
 (defun magik-yasnippet-prev-pragma ()
   "Search for the previous pragma in the buffer.

--- a/snippets/magik-mode/.yas-setup.el
+++ b/snippets/magik-mode/.yas-setup.el
@@ -19,28 +19,28 @@
   :group 'magik-yasnippet
   :type  'string)
 
-(defcustom magik-yasnippet-documentation-style 'sw-method-docs
-  "Choose between \\'sw-method-docs\\', \\'type-docs\\', or nil.
-\\'sw-method-docs\\' for Smallworld method documentation style.
-\\'type-docs\\' for type-based documentation.
+(defcustom magik-yasnippet-documentation-style 'sw-method-doc
+  "Choose between \\'sw-method-doc\\', \\'type-doc\\', or nil.
+\\'sw-method-doc\\' for Smallworld method documentation style.
+\\'type-doc\\' for type-based documentation.
 nil to disable documentation."
   :group 'magik-yasnippet
-  :type  '(choice (const :tag "Smallworld Method Docs" sw-method-docs)
-                  (const :tag "Type Docs" type-docs)
-                  (const :tag "No Documentation" nil)))
+  :type  '(choice (const :tag "Smallworld method documentation style" sw-method-doc)
+                  (const :tag "Type-based documentation" type-doc)
+                  (const :tag "No documentation" nil)))
 
 (defcustom magik-yasnippet-default-documentation "\t## \n\t## \n\t## "
   "Default documentation string to insert."
   :group 'magik-yasnippet
   :type  'string)
 
-(defcustom magik-yasnippet-sw-method-docs-documentation magik-yasnippet-default-documentation
-  "Default sw-method-docs documentation string to insert."
+(defcustom magik-yasnippet-sw-method-doc-documentation magik-yasnippet-default-documentation
+  "Default sw-method-doc documentation string to insert."
   :group 'magik-yasnippet
   :type  'string)
 
-(defcustom magik-yasnippet-type-docs-documentation magik-yasnippet-default-documentation
-  "Default type-docs documentation string to insert."
+(defcustom magik-yasnippet-type-doc-documentation magik-yasnippet-default-documentation
+  "Default type-doc documentation string to insert."
   :group 'magik-yasnippet
   :type  'string)
 
@@ -52,8 +52,8 @@ nil to disable documentation."
 If UNTABBED is non-nil remove the tabs from the documentation string."
   (if magik-yasnippet-documentation-style
       (let ((documentation-string (pcase magik-yasnippet-documentation-style
-                                    ('sw-method-docs magik-yasnippet-sw-method-docs-documentation)
-                                    ('type-docs magik-yasnippet-type-docs-documentation))))
+                                    ('sw-method-doc magik-yasnippet-sw-method-doc-documentation)
+                                    ('type-doc magik-yasnippet-type-doc-documentation))))
         (if untabbed
             (replace-regexp-in-string "\t" "" documentation-string)
           documentation-string))

--- a/snippets/magik-mode/.yas-setup.el
+++ b/snippets/magik-mode/.yas-setup.el
@@ -34,26 +34,37 @@ nil to disable documentation."
   :group 'magik-yasnippet
   :type  'string)
 
-(defcustom magik-yasnippet-sw-method-doc-documentation magik-yasnippet-default-documentation
+(defcustom magik-yasnippet-sw-method-doc-documentation 'default
   "Default sw-method-doc documentation string to insert."
   :group 'magik-yasnippet
-  :type  'string)
+  :type  '(choice (const :tag "Use default documentation" default)
+                  (string :tag "Custom sw-method-doc")))
 
-(defcustom magik-yasnippet-type-doc-documentation magik-yasnippet-default-documentation
+(defcustom magik-yasnippet-type-doc-documentation 'default
   "Default type-doc documentation string to insert."
   :group 'magik-yasnippet
-  :type  'string)
+  :type  '(choice (const :tag "Use default documentation" default)
+                  (string :tag "Custom type-doc")))
 
 (defconst magik-yasnippet--class-name-regexp "\\(\\(\\sw\\|_\\)+\\)"
   "The regexp to use for the Magik class name.")
 
+(defun magik-yasnippet--documentation-string (value)
+  "Return the documentation string based on VALUE.
+If VALUE is \\'default, return `magik-yasnippet-default-documentation'.
+Otherwise, return VALUE."
+  (if (eq value 'default)
+      magik-yasnippet-default-documentation
+    value))
+
 (defun magik-yasnippet-documentation (&optional untabbed)
   "Insert the documentation string based on `magik-yasnippet-documentation-style'.
-If UNTABBED is non-nil remove the tabs from the documentation string."
+If UNTABBED is non-nil remove the tabs from the documentation string.
+When documentation style is nil (disabled), it kills the current line."
   (if magik-yasnippet-documentation-style
       (let ((documentation-string (pcase magik-yasnippet-documentation-style
-                                    ('sw-method-doc magik-yasnippet-sw-method-doc-documentation)
-                                    ('type-doc magik-yasnippet-type-doc-documentation))))
+                                    ('sw-method-doc (magik-yasnippet--documentation-string magik-yasnippet-sw-method-doc-documentation))
+                                    ('type-doc (magik-yasnippet--documentation-string magik-yasnippet-type-doc-documentation)))))
         (if untabbed
             (replace-regexp-in-string "\t" "" documentation-string)
           documentation-string))

--- a/snippets/magik-mode/abstract_method
+++ b/snippets/magik-mode/abstract_method
@@ -6,9 +6,7 @@
 # --
 `(magik-yasnippet-prev-pragma)`
 _abstract _method `(magik-yasnippet-prev-class-name-with-dot)`${1:name}
-	## 
-	## 
-	## 
+`(magik-yasnippet-documentation)`
 	$0
 _endmethod
 $

--- a/snippets/magik-mode/construct
+++ b/snippets/magik-mode/construct
@@ -7,18 +7,14 @@
 # --
 `(magik-yasnippet-prev-pragma)`
 _method `(magik-yasnippet-prev-class-name-with-dot)`new()
-	## 
-	## 
-	## 
+`(magik-yasnippet-documentation)`
 	>> _clone.init()
 _endmethod
 $
 
 `(magik-yasnippet-prev-pragma)`
 _private _method `(magik-yasnippet-prev-class-name-with-dot)`init()
-	## 
-	## 
-	## 
+`(magik-yasnippet-documentation)`
 `(magik-yasnippet-prev-slotted-exemplar-slots)`
 	>> _self
 _endmethod

--- a/snippets/magik-mode/def_indexed_exemplar
+++ b/snippets/magik-mode/def_indexed_exemplar
@@ -4,9 +4,7 @@
 # group: object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-##
-##
-##
+`(magik-yasnippet-documentation t)`
 def_indexed_exemplar(:${1:`(magik-yasnippet-filename)`}, ${2:$$(yas-completing-read "Data type: " '(":pointer" ":signed8" ":unsigned8" ":char8" ":signed16" ":unsigned16" ":char16" ":signed32" ":unsigned32" ":char32" ":float32" ":signed64" ":unsigned64" ":float64"))})
 $
 

--- a/snippets/magik-mode/def_mixin
+++ b/snippets/magik-mode/def_mixin
@@ -4,7 +4,7 @@
 # group: object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 def_mixin(:${1:`(magik-yasnippet-filename)`})
 $
 

--- a/snippets/magik-mode/def_mixin
+++ b/snippets/magik-mode/def_mixin
@@ -4,9 +4,7 @@
 # group: object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-## 
-## 
-## 
+`(magik-yasnippet-documentation)`
 def_mixin(:${1:`(magik-yasnippet-filename)`})
 $
 

--- a/snippets/magik-mode/def_property
+++ b/snippets/magik-mode/def_property
@@ -4,9 +4,7 @@
 # group: define.object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-## 
-## 
-## 
+`(magik-yasnippet-documentation)`
 `(magik-yasnippet-prev-class-name-with-dot)`def_property(:${1:name})
 $
 

--- a/snippets/magik-mode/def_property
+++ b/snippets/magik-mode/def_property
@@ -4,7 +4,7 @@
 # group: define.object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 `(magik-yasnippet-prev-class-name-with-dot)`def_property(:${1:name})
 $
 

--- a/snippets/magik-mode/def_slotted_exemplar
+++ b/snippets/magik-mode/def_slotted_exemplar
@@ -5,7 +5,7 @@
 # group: object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 def_slotted_exemplar(:${1:`(magik-yasnippet-filename)`},
 		     {
 			     $2

--- a/snippets/magik-mode/def_slotted_exemplar
+++ b/snippets/magik-mode/def_slotted_exemplar
@@ -5,9 +5,7 @@
 # group: object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-## 
-## 
-## 
+`(magik-yasnippet-documentation)`
 def_slotted_exemplar(:${1:`(magik-yasnippet-filename)`},
 		     {
 			     $2

--- a/snippets/magik-mode/define_shared_constant
+++ b/snippets/magik-mode/define_shared_constant
@@ -4,9 +4,7 @@
 # group: define.object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-## 
-## 
-## 
+`(magik-yasnippet-documentation)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_shared_constant(:${1:name}, ${2:value}, ${3:$$(yas-completing-read
 "Private?:
 ##  private?         get

--- a/snippets/magik-mode/define_shared_constant
+++ b/snippets/magik-mode/define_shared_constant
@@ -4,7 +4,7 @@
 # group: define.object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_shared_constant(:${1:name}, ${2:value}, ${3:$$(yas-completing-read
 "Private?:
 ##  private?         get

--- a/snippets/magik-mode/define_shared_variable
+++ b/snippets/magik-mode/define_shared_variable
@@ -4,7 +4,7 @@
 # group: define.object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_shared_variable(:${1:name}, ${2:initial_value}, ${3:$$(yas-completing-read
 "Flavour?:
 ##  flavour    get  set  boot

--- a/snippets/magik-mode/define_shared_variable
+++ b/snippets/magik-mode/define_shared_variable
@@ -4,9 +4,7 @@
 # group: define.object oriented
 # --
 `(magik-yasnippet-prev-pragma)`
-## 
-## 
-## 
+`(magik-yasnippet-documentation)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_shared_variable(:${1:name}, ${2:initial_value}, ${3:$$(yas-completing-read
 "Flavour?:
 ##  flavour    get  set  boot

--- a/snippets/magik-mode/define_slot_access
+++ b/snippets/magik-mode/define_slot_access
@@ -4,9 +4,7 @@
 # group: object oriented.slot
 # --
 `(magik-yasnippet-prev-pragma)`
-## 
-## 
-## 
+`(magik-yasnippet-documentation)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_slot_access(:${1:name}, ${2:$$(yas-completing-read
 "Flag?:
 ##  flag               flavour        get  set  boot

--- a/snippets/magik-mode/define_slot_access
+++ b/snippets/magik-mode/define_slot_access
@@ -4,7 +4,7 @@
 # group: object oriented.slot
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_slot_access(:${1:name}, ${2:$$(yas-completing-read
 "Flag?:
 ##  flag               flavour        get  set  boot

--- a/snippets/magik-mode/define_slot_externally_readable
+++ b/snippets/magik-mode/define_slot_externally_readable
@@ -4,7 +4,7 @@
 # group: object oriented.slot
 # --
 `(magik-yasnippet-prev-pragma)`
-`(magik-yasnippet-documentation)`
+`(magik-yasnippet-documentation t)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_slot_externally_readable(:${1:name})
 $
 

--- a/snippets/magik-mode/define_slot_externally_readable
+++ b/snippets/magik-mode/define_slot_externally_readable
@@ -4,9 +4,7 @@
 # group: object oriented.slot
 # --
 `(magik-yasnippet-prev-pragma)`
-##
-##
-##
+`(magik-yasnippet-documentation)`
 `(magik-yasnippet-prev-class-name-with-dot)`define_slot_externally_readable(:${1:name})
 $
 

--- a/snippets/magik-mode/iter_method
+++ b/snippets/magik-mode/iter_method
@@ -6,9 +6,7 @@
 # --
 `(magik-yasnippet-prev-pragma)`
 _iter _method `(magik-yasnippet-prev-class-name-with-dot)`${1:name}
-	## 
-	## 
-	## 
+`(magik-yasnippet-documentation)`
 	$0
 _endmethod
 $

--- a/snippets/magik-mode/method
+++ b/snippets/magik-mode/method
@@ -6,9 +6,7 @@
 # --
 `(magik-yasnippet-prev-pragma)`
 _method `(magik-yasnippet-prev-class-name-with-dot)`${1:name}
-	## 
-	## 
-	## 
+`(magik-yasnippet-documentation)`
 	$0
 _endmethod
 $

--- a/snippets/magik-mode/private_method
+++ b/snippets/magik-mode/private_method
@@ -6,9 +6,7 @@
 # --
 `(magik-yasnippet-prev-pragma)`
 _private _method `(magik-yasnippet-prev-class-name-with-dot)`${1:name}
-	## 
-	## 
-	## 
+`(magik-yasnippet-documentation)`
 	$0
 _endmethod
 $


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced customizable options for documentation styles, allowing users to select from multiple documentation formats.
  - Integrated a dynamic documentation insertion mechanism that populates snippets with context-specific content during template expansion.

- **Refactor**
  - Updated snippet templates across various constructs by replacing placeholder comments with functional documentation calls, enhancing clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->