### PR TITLE
[magik-module] Convert to a symbol instead of a string

### DIFF
--- a/magik-module.el
+++ b/magik-module.el
@@ -206,7 +206,7 @@ option is set."
 
 (defun magik-module-name-with-pipes ()
   "Return the name of the current module, surrounded by pipes (\"|\")."
-  (format "|%s|" (magik-utils-module-name)))
+  (intern (format "|%s|" (magik-utils-module-name))))
 
 (defun magik-module-reload-module-definition (&optional gis)
   "Reload the module definition in the GIS process."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated a public API to return a symbol instead of a string. This may affect integrations that expect a string (e.g., formatting or transmission). Consumers should verify compatibility and adjust accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->